### PR TITLE
Add protocol selection for OBD2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# CarCare++
+
+CarCare++ is an Android application for monitoring your vehicle via OBD2 and managing car related services.
+
+## OBD2 Protocol Selection
+
+Before connecting to an ELM327 adapter you can choose the OBD2 protocol from a drop-down in the dashboard screen. The selected protocol is sent with the `ATSP` command when initializing the adapter. The choice is saved for future sessions.
+

--- a/app/src/main/res/layout/activity_car.xml
+++ b/app/src/main/res/layout/activity_car.xml
@@ -557,6 +557,20 @@
                 </LinearLayout>
             </com.google.android.material.card.MaterialCardView>
 
+            <TextView
+                android:id="@+id/tvProtocolLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="@string/obd2_protocol_label"
+                android:textAppearance="?attr/textAppearanceBodyMedium"
+                android:textColor="?attr/colorOnSurface" />
+            <Spinner
+                android:id="@+id/spinnerProtocol"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="12dp" />
+
             <!-- Quick Services -->
             <TextView
                 android:layout_width="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -126,4 +126,30 @@
     <!-- Close Button Text for Dialog -->
     <string name="dialog_close_button">Close</string>
 
+    <string name="obd2_protocol_label">OBD2 Protocol</string>
+    <string-array name="obd2_protocol_display">
+        <item>Automatic (0)</item>
+        <item>SAE J1850 PWM (1)</item>
+        <item>SAE J1850 VPW (2)</item>
+        <item>ISO 9141-2 (3)</item>
+        <item>ISO 14230-4 KWP 5 baud (4)</item>
+        <item>ISO 14230-4 KWP fast (5)</item>
+        <item>ISO 15765-4 CAN 11/500 (6)</item>
+        <item>ISO 15765-4 CAN 29/500 (7)</item>
+        <item>ISO 15765-4 CAN 11/250 (8)</item>
+        <item>ISO 15765-4 CAN 29/250 (9)</item>
+    </string-array>
+    <string-array name="obd2_protocol_codes">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+        <item>4</item>
+        <item>5</item>
+        <item>6</item>
+        <item>7</item>
+        <item>8</item>
+        <item>9</item>
+    </string-array>
+
 </resources>


### PR DESCRIPTION
## Summary
- let the OBD2 manager keep a selected protocol
- expose the selected protocol in initialization commands
- allow selecting protocol from CarActivity
- add protocol options to resources and layout
- document how to choose the protocol

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_683f74e33f6c8329a47d2b44547fd598